### PR TITLE
Shellcheck for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
     - bash run_tests.sh
     - shellcheck ../mockmaker
     - shellcheck mocks/*
+    - shellcheck *.sh

--- a/tests/func.sh
+++ b/tests/func.sh
@@ -1,45 +1,48 @@
 #!/bin/bash
 
-
 check_outputs () {
-    local readonly command="$@"
-    local readonly hashed=$(echo -n "${command}" | md5sum | cut -d" " -f1)
+    command=( "$@" )
+    hashed=$(echo -n "${command[@]}" | md5sum | cut -d" " -f1)
 
-    ${command} > orig_${hashed}_stdout.txt 2> orig_${hashed}_stderr.txt
-    echo "$?" > orig_${hashed}_exitcode.txt
+    ${command[@]} > "orig_${hashed}_stdout.txt" 2> "orig_${hashed}_stderr.txt"
+    echo "$?" > "orig_${hashed}_exitcode.txt"
 
-    ./mockmaker ${command} > /dev/null 2>&1
+    ./mockmaker ${command[@]} > /dev/null 2>&1
 
-    cd mocks
-    ./${command} > ../mock_${hashed}_stdout.txt 2> ../mock_${hashed}_stderr.txt
-    echo "$?" > ../mock_${hashed}_exitcode.txt
+    cd mocks || exit 1
+    ./${command[*]} > "../mock_${hashed}_stdout.txt" 2> "../mock_${hashed}_stderr.txt"
+    echo "$?" > "../mock_${hashed}_exitcode.txt"
     cd ..
 
     local outcome=0
 
     echo "Checking stdout.."
-    diff orig_${hashed}_stdout.txt mock_${hashed}_stdout.txt
+    diff "orig_${hashed}_stdout.txt" "mock_${hashed}_stdout.txt"
     if [ $? -ne 0 ]; then
         echo "FAIL: stdouts differ"
         outcome=1
     fi
 
     echo "Checking stderr.."
-    diff orig_${hashed}_stderr.txt mock_${hashed}_stderr.txt
+    diff "orig_${hashed}_stderr.txt" "mock_${hashed}_stderr.txt"
     if [ $? -ne 0 ]; then
         echo "FAIL: stderrs differ"
         outcome=1
     fi
 
     echo "Checking exit code.."
-    diff orig_${hashed}_exitcode.txt mock_${hashed}_exitcode.txt
+    diff "orig_${hashed}_exitcode.txt" "mock_${hashed}_exitcode.txt"
     if [ $? -ne 0 ]; then
         echo "FAIL: exitcodes differ"
         outcome=1
     fi
 
-    rm orig_${hashed}_*
-    rm mock_${hashed}_*
+    rm "orig_${hashed}_stdout.txt"
+    rm "orig_${hashed}_stderr.txt"
+    rm "orig_${hashed}_exitcode.txt"
+    rm "mock_${hashed}_stdout.txt"
+    rm "mock_${hashed}_stderr.txt"
+    rm "mock_${hashed}_exitcode.txt"
 
     return $outcome
 }

--- a/tests/func.sh
+++ b/tests/func.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 check_outputs () {
-    command=( "$@" )
-    hashed=$(echo -n "${command[@]}" | md5sum | cut -d" " -f1)
+    local command
+    readonly command=( "$@" )
+    local hashed
+    readonly hashed=$(echo -n "${command[@]}" | md5sum | cut -d" " -f1)
 
     # shellcheck disable=SC2068
     ${command[@]} > "orig_${hashed}_stdout.txt" 2> "orig_${hashed}_stderr.txt"

--- a/tests/func.sh
+++ b/tests/func.sh
@@ -4,12 +4,15 @@ check_outputs () {
     command=( "$@" )
     hashed=$(echo -n "${command[@]}" | md5sum | cut -d" " -f1)
 
+    # shellcheck disable=SC2068
     ${command[@]} > "orig_${hashed}_stdout.txt" 2> "orig_${hashed}_stderr.txt"
     echo "$?" > "orig_${hashed}_exitcode.txt"
 
+    # shellcheck disable=SC2068
     ./mockmaker ${command[@]} > /dev/null 2>&1
 
     cd mocks || exit 1
+    # shellcheck disable=SC2086
     ./${command[*]} > "../mock_${hashed}_stdout.txt" 2> "../mock_${hashed}_stderr.txt"
     echo "$?" > "../mock_${hashed}_exitcode.txt"
     cd ..

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,7 +4,7 @@ outcome=0
 
 for f in test_*.sh; do
     echo "Running ${f} test suite"
-    ./${f}
+    "./${f}"
     if [ $? -ne 0 ]; then
         echo "ERROR: Test failed: ${f}" >&2
         let outcome+=1

--- a/tests/test_git_help.sh
+++ b/tests/test_git_help.sh
@@ -3,5 +3,5 @@
 command="git --help"
 
 source ./func.sh
-check_outputs $command
+check_outputs "$command"
 exit $?

--- a/tests/test_git_thiswillfail.sh
+++ b/tests/test_git_thiswillfail.sh
@@ -3,5 +3,5 @@
 command="git thiswillfail"
 
 source ./func.sh
-check_outputs $command
+check_outputs "$command"
 exit $?

--- a/tests/test_git_version.sh
+++ b/tests/test_git_version.sh
@@ -3,5 +3,5 @@
 command="git version"
 
 source ./func.sh
-check_outputs $command
+check_outputs "$command"
 exit $?

--- a/tests/test_unknown_args.sh
+++ b/tests/test_unknown_args.sh
@@ -5,7 +5,7 @@ command_check="git aaaaaaaa"
 
 outcome=0
 
-./mockmaker ${command} > /dev/null 2>&1
+./mockmaker "${command}" > /dev/null 2>&1
 cd mocks
 ./${command_check} > test_unknown_args_stdout.txt 2> test_unknown_args_stderr.txt
 if [ $? -ne 1 ]; then

--- a/tests/test_unknown_args.sh
+++ b/tests/test_unknown_args.sh
@@ -6,7 +6,8 @@ command_check="git aaaaaaaa"
 outcome=0
 
 ./mockmaker "${command}" > /dev/null 2>&1
-cd mocks
+cd mocks || exit 1
+# shellcheck disable=SC2086
 ./${command_check} > test_unknown_args_stdout.txt 2> test_unknown_args_stderr.txt
 if [ $? -ne 1 ]; then
     >&2 echo "FAIL: Mock should fail with error code 1"


### PR DESCRIPTION
Tests also should be written with proper code, so lets shellcheck them.

All non-breaking fixes proposed by shellcheck were applied, but there are 4 instances that could still use some work.
