### PR TITLE
Include shellcheck in run_tests.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,4 @@ addons:
 script:
     - cd tests/
     - bash run_tests.sh
-    - shellcheck ../mockmaker
-    - shellcheck mocks/*
-    - shellcheck *.sh
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -24,7 +24,7 @@ let outcome+=$?
 if [ "$1" != "--skip-shellcheck" ]; then
     run_tests "shellcheck_test_*.sh"
     let outcome+=$?
-    echo "Ypu can skip shellcheck tests with --skip-shellcheck"
+    echo "You can skip shellcheck tests with --skip-shellcheck"
 else
     echo "Skipping shellcheck..."
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,6 +3,7 @@
 run_tests () {
     outcome_tmp=0
 
+    # shellcheck disable=SC2048
     for f in $*; do
         echo "Running ${f} test suite"
         "./${f}"
@@ -27,6 +28,5 @@ if [ "$1" != "--skip-shellcheck" ]; then
 else
     echo "Skipping shellcheck..."
 fi
-
 
 exit $outcome

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
 
+run_tests () {
+    outcome_tmp=0
+
+    for f in $*; do
+        echo "Running ${f} test suite"
+        "./${f}"
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Test failed: ${f}" >&2
+            let outcome_tmp+=1
+        fi
+        echo ""
+    done
+    return $outcome_tmp
+}
+
 outcome=0
 
-for f in test_*.sh; do
-    echo "Running ${f} test suite"
-    "./${f}"
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Test failed: ${f}" >&2
-        let outcome+=1
-    fi
-    echo ""
-done
+run_tests "test_*.sh"
+let outcome+=$?
+
+if [ "$1" != "--skip-shellcheck" ]; then
+    run_tests "shellcheck_test_*.sh"
+    let outcome+=$?
+    echo "Ypu can skip shellcheck tests with --skip-shellcheck"
+else
+    echo "Skipping shellcheck..."
+fi
+
 
 exit $outcome

--- a/tests/shellcheck_test_mockmaker.sh
+++ b/tests/shellcheck_test_mockmaker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+shellcheck ../mockmaker
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+

--- a/tests/shellcheck_test_mocks.sh
+++ b/tests/shellcheck_test_mocks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+shellcheck mocks/*
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+

--- a/tests/shellcheck_test_tests.sh
+++ b/tests/shellcheck_test_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+shellcheck *.sh
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+

--- a/tests/shellcheck_test_tests.sh
+++ b/tests/shellcheck_test_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-shellcheck *.sh
+shellcheck ./*.sh
 if [ $? -ne 0 ]; then
     exit 1
 fi


### PR DESCRIPTION
shellcheck should be ran by run_tests.sh instead of .travis.yml

Also, provide option to disable shellcheck tests in order to keep it working on dev platforms lacking shellcheck.
